### PR TITLE
Remove schema from consumers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: up down test
+
+test: up
+	rspec spec
+	$(MAKE) down
+
+up:
+	docker-compose up -d
+
+down:
+	docker-compose down -v

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ consumer2 = consumer_group.create(
 # Methods for consuming messages. You can specify a block which processes
 # messages one by one, or retrieve the messages in bulk
 
-messages = consumer1.consume('avro-topic', key_schema: ks, value_schema: vs)
-consumer2.consume('avro-topic', key_schema: ks, value_schema: vs) do |message|
+messages = consumer1.consume('avro-topic')
+consumer2.consume('avro-topic') do |message|
   puts message.key, message.value
 end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+  kafka:
+    image: confluentinc/cp-kafka
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+  schema-registry:
+    image: confluentinc/cp-schema-registry
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
+      SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+  rest-proxy:
+    image: confluentinc/cp-kafka-rest
+    environment:
+      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_REST_LISTENERS: http://rest-proxy:8082
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      KAFKA_REST_HOST_NAME: rest-proxy
+    ports:
+      - "8082:8082"

--- a/lib/kafka_rest/version.rb
+++ b/lib/kafka_rest/version.rb
@@ -1,3 +1,3 @@
 module KafkaRest
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Summary:
Remove value_schema and key_schema from consumer as they are unnecessary. Previously, the schemas were used to infer the content type and serialization/deserialization rules for a particular message. However, neither of these things actually require the message schema, they just require knowledge of the message schema _type_. That is, I need to know whether or not the message was serialized with Avro, Json, or Binary, but I don't actually need the schema itself. This information was already available in the consumer via the `format` parameter. Removing this clarifies the API non-requirement of consumer schemas and overall makes the API cleaner.

Tests:
Ran VCR test in the spec folder. Note: these need to be updated, but will address that in a separate PR